### PR TITLE
Fix package distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Rally REST Toolkit for Node.js",
   "contributors": [
     {
@@ -17,7 +17,6 @@
     }
   ],
   "main": "dist/index.js",
-  "esnext": "lib/index.js",
   "scripts": {
     "build": "cross-env BABEL_ENV=commonjs babel lib --out-dir dist",
     "lint": "eslint .",
@@ -41,6 +40,7 @@
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-1": "6.5.0",
+    "babel-runtime": "6.11.6",
     "cross-env": "2.0.0",
     "eslint": "2.13.1",
     "mocha": "2.5.3",

--- a/spec/restapi.spec.js
+++ b/spec/restapi.spec.js
@@ -75,10 +75,10 @@ describe('RestApi', () => {
       const restApi = new RestApi();
       const initArgs = Request.default.firstCall.args[0];
       initArgs.requestOptions.headers.should.eql({
-        'X-RallyIntegrationLibrary': 'Rally REST Toolkit for Node.js v1.0.0',
+        'X-RallyIntegrationLibrary': 'Rally REST Toolkit for Node.js v1.1.0',
         'X-RallyIntegrationName': 'Rally REST Toolkit for Node.js',
         'X-RallyIntegrationVendor': 'Rally Software, Inc.',
-        'X-RallyIntegrationVersion': '1.0.0'
+        'X-RallyIntegrationVersion': '1.1.0'
       });
       restApi.request.should.be.exactly(Request.default.firstCall.returnValue);
     });


### PR DESCRIPTION
We were picking up .gitignores config and ignoring dist, which is needed in the published package for consumption by non-es6 consumers.

- Added .npmignore so we don't ignore dist (from .gitignore)
- Removed esnext option
- Bumped version as minor bump