### PR TITLE
Reject promises

### DIFF
--- a/examples/crud.callback.js
+++ b/examples/crud.callback.js
@@ -2,8 +2,8 @@ const rally = require('..');
 const restApi = rally();
 const refUtils = rally.util.ref;
 
-function onError(errors) {
-    console.log('Failure!', errors);
+function onError(error) {
+    console.log('Failure!', error.message, error.errors);
 }
 
 function createDefect() {

--- a/examples/crud.promise.js
+++ b/examples/crud.promise.js
@@ -48,8 +48,8 @@ function onSuccess(result) {
     console.log('Success!', result);
 }
 
-function onError(errors) {
-    console.log('Failure!', errors);
+function onError(error) {
+    console.log('Failure!', error.message, error.errors);
 }
 
 createDefect()

--- a/examples/query.callback.js
+++ b/examples/query.callback.js
@@ -3,7 +3,7 @@ const restApi = rally();
 const queryUtils = rally.util.query;
 
 function onError(error) {
-    console.log('Failure!', error);
+    console.log('Failure!', error.message, error.errors);
 }
 
 function queryChildren(result) {

--- a/examples/query.promise.js
+++ b/examples/query.promise.js
@@ -30,8 +30,8 @@ function onSuccess(result) {
     console.log('Success!', result);
 }
 
-function onError(errors) {
-    console.log('Failure!', errors);
+function onError(error) {
+    console.log('Failure!', error.message, error.errors);
 }
 
 queryEpicStories()

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,6 +2,11 @@ import request from 'request';
 import _ from 'lodash';
 import callbackify from './util/callbackify';
 
+const generateError = (errorMessages) => {
+  const e = new Error(errorMessages[0]);
+  e.errors = errorMessages;
+  return e;
+}
 export default class Request {
   constructor(options) {
     this.wsapiUrl = `${options.server}/slm/webservice/${options.apiVersion}`;
@@ -60,15 +65,15 @@ export default class Request {
       });
       this.httpRequest[method](requestOptions, (err, response, body) => {
         if (err) {
-          reject([err]);
+          reject(generateError([err]));
         } else if (!response) {
-          reject([`Unable to connect to server: ${this.wsapiUrl}`]);
+          reject(generateError([`Unable to connect to server: ${this.wsapiUrl}`]));
         } else if (!body || !_.isObject(body)) {
-          reject([`${options.url}: ${response.statusCode}! body=${body}`]);
+          reject(generateError([`${options.url}: ${response.statusCode}! body=${body}`]));
         } else {
           const result = _.values(body)[0];
           if (result.Errors.length) {
-            reject(result.Errors);
+            reject(generateError(result.Errors));
           } else {
             resolve(result);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Rally REST Toolkit for Node.js",
   "contributors": [
     {

--- a/spec/request.spec.js
+++ b/spec/request.spec.js
@@ -66,7 +66,7 @@ describe('Request', () => {
       const error = 'Error!';
       get.yieldsAsync(error);
       rr.doRequest('get', {url: '/someUrl'}, (err, body) => {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         should.not.exist(body);
         done();
       });
@@ -80,7 +80,7 @@ describe('Request', () => {
         await rr.doRequest('get', {url: '/someUrl'});
         fail('expected promise to be rejected');
       } catch (err) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         done();
       }
     });
@@ -89,7 +89,7 @@ describe('Request', () => {
         const rr = createRequest();
         get.yieldsAsync(null, null);
         rr.doRequest('get', {url: '/someUrl'}, (err, body) => {
-          err.should.eql(['Unable to connect to server: ' + rr.wsapiUrl]);
+          err.errors.should.eql(['Unable to connect to server: ' + rr.wsapiUrl]);
           should.not.exist(body);
           done();
         });
@@ -102,7 +102,7 @@ describe('Request', () => {
         await rr.doRequest('get', {url: '/someUrl'});
         fail('expected promise to be rejected');
       } catch (err) {
-        err.should.eql(['Unable to connect to server: ' + rr.wsapiUrl]);
+        err.errors.should.eql(['Unable to connect to server: ' + rr.wsapiUrl]);
         done();
       }
     });
@@ -111,7 +111,7 @@ describe('Request', () => {
       const rr = createRequest();
       get.yieldsAsync(null, {statusCode: 404}, 'not found!');
       rr.doRequest('get', {url: '/someUrl'}, (err, body) => {
-        err.should.eql(['/someUrl: 404! body=not found!']);
+        err.errors.should.eql(['/someUrl: 404! body=not found!']);
         should.not.exist(body);
         done();
       });
@@ -124,7 +124,7 @@ describe('Request', () => {
         await rr.doRequest('get', {url: '/someUrl'});
         fail('expected promise to be rejected');
       } catch (err) {
-        err.should.eql(['/someUrl: 404! body=not found!']);
+        err.errors.should.eql(['/someUrl: 404! body=not found!']);
         done();
       }
     });
@@ -138,7 +138,7 @@ describe('Request', () => {
         await rr.doRequest('get', {url: '/someUrl'});
         fail('expected promise to be rejected');
       } catch (err) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         done();
       }
     });
@@ -220,7 +220,7 @@ describe('Request', () => {
       const error = 'Some key error';
       get.yieldsAsync(null, {}, {OperationResult: {Errors: [error]}});
       rr.doSecuredRequest('put', {}, function(err, result) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         should.not.exist(result);
         done();
       });
@@ -233,7 +233,7 @@ describe('Request', () => {
       try {
         await rr.doSecuredRequest('put', {});
       } catch (err) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         done();
       }
     });
@@ -248,7 +248,7 @@ describe('Request', () => {
         await rr.doSecuredRequest('put', {});
         fail('promise should be rejected');
       } catch (err) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
       }
       done();
     });
@@ -260,7 +260,7 @@ describe('Request', () => {
       get.yieldsAsync(null, {}, {OperationResult: {Errors: [], Warnings: [], SecurityToken: 'foo'}});
       put.yieldsAsync(null, {}, putResponseBody);
       rr.doSecuredRequest('put', {}, function(err, result) {
-        err.should.eql([error]);
+        err.errors.should.eql([error]);
         should.not.exist(result);
         done();
       });

--- a/spec/restapi.spec.js
+++ b/spec/restapi.spec.js
@@ -3,6 +3,7 @@ import RestApi from '../lib/restapi';
 import * as Request from '../lib/request';
 import { where } from '../lib/util/query';
 import sinon from 'sinon';
+import packageJson from '../package.json';
 
 describe('RestApi', () => {
   let del, get, post, put;
@@ -75,10 +76,10 @@ describe('RestApi', () => {
       const restApi = new RestApi();
       const initArgs = Request.default.firstCall.args[0];
       initArgs.requestOptions.headers.should.eql({
-        'X-RallyIntegrationLibrary': 'Rally REST Toolkit for Node.js v1.1.0',
+        'X-RallyIntegrationLibrary': `Rally REST Toolkit for Node.js v${packageJson.version}`,
         'X-RallyIntegrationName': 'Rally REST Toolkit for Node.js',
         'X-RallyIntegrationVendor': 'Rally Software, Inc.',
-        'X-RallyIntegrationVersion': '1.1.0'
+        'X-RallyIntegrationVersion': packageJson.version
       });
       restApi.request.should.be.exactly(Request.default.firstCall.returnValue);
     });


### PR DESCRIPTION
Promises should always be rejected with instances of Error. Doing this will propagate the stack traces correctly when failures occur.