### PR TITLE
feat(exports): Change export from factory to map with new `createClient` factory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,11 @@ import RestApi from './restapi';
 import { where } from './util/query';
 import ref from './util/ref';
 
-const restapi = options => new RestApi(options);
-restapi.debug = process.env.NODE_DEBUG && /rally/.test(process.env.NODE_DEBUG);
+const createClient = options => new RestApi(options);
+
+const restapi = createClient;
+restapi.createClient = createClient;
+restapi.debug = process.env.NODE_DEBUG && /rally/.test(process.env.NODE_DEBUG),
 restapi.util = {
   query: { where },
   ref

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Rally REST Toolkit for Node.js",
   "contributors": [
     {


### PR DESCRIPTION
In our environment, we can't stub the default `rally` export without a good amount of misdirection.

The `add-module-exports` plugin in the .babelrc assigns `export.default` to `module.exports`, which creates a situation where we can't stub `rally.default`. In order to continue smooth module interop between commonjs & es6 syntax, and allow stubbing/spying of the factory function, we've changed the default export to an Object that has a `createClient` method to create new rally clients.

This is a backwards incompatible change as it changes the public API. A major bump has been included in the PR.